### PR TITLE
Docs: Add an example page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>live-region-element</title>
+  </head>
+  <body>
+    <main>
+      <h1>live-region-element</h1>
+      <h2>announce</h2>
+
+      <h3>Polite</h3>
+      <button id="js-announce-polite">Announce</button>
+
+      <h3>Assertive</h3>
+      <button id="js-announce-assertive">Announce</button>
+
+      <h2>announceFromElement</h2>
+      <h3>Polite</h3>
+      <p id="some-text">Hello world.</p>
+      <button id="js-announce-el-polite">Announce</button>
+
+      <h3>Assertive</h3>
+      <p id="more-text">Goodbye for now.</p>
+      <button id="js-announce-el-assertive">Announce</button>
+
+      <live-region>
+        <template shadowrootmode="open">
+          <style>
+            :host {
+              clip-path: inset(50%);
+              height: 1px;
+              overflow: hidden;
+              position: absolute;
+              white-space: nowrap;
+              width: 1px;
+            }
+          </style>
+          <div id="polite" aria-live="polite" aria-atomic="true"></div>
+          <div id="assertive" aria-live="assertive" aria-atomic="true"></div>
+        </template>
+      </live-region>
+    </main>
+
+    <script type="module" src="../dist/esm/index.js"></script>
+    <script>
+      document.getElementById('js-announce-polite').addEventListener('click', () => {
+        const liveRegion = document.querySelector('live-region')
+        liveRegion.announce('Example polite message', {
+          politeness: 'polite',
+        })
+      })
+
+      document.getElementById('js-announce-assertive').addEventListener('click', () => {
+        const liveRegion = document.querySelector('live-region')
+        liveRegion.announce('Example assertive message', {
+          politeness: 'assertive',
+        })
+      })
+
+      document.getElementById('js-announce-el-polite').addEventListener('click', () => {
+        const liveRegion = document.querySelector('live-region')
+        liveRegion.announceFromElement(document.querySelector('#some-text'), {
+          politeness: 'polite',
+        })
+      })
+
+      document.getElementById('js-announce-el-assertive').addEventListener('click', () => {
+        const liveRegion = document.querySelector('live-region')
+        liveRegion.announceFromElement(document.querySelector('#more-text'), {
+          politeness: 'assertive',
+        })
+      })
+    </script>
+
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,19 +9,19 @@
       <h2>announce</h2>
 
       <h3>Polite</h3>
-      <button id="js-announce-polite">Announce</button>
+      <button id="js-announce-polite">Announce politely</button>
 
       <h3>Assertive</h3>
-      <button id="js-announce-assertive">Announce</button>
+      <button id="js-announce-assertive">Announce assertively</button>
 
       <h2>announceFromElement</h2>
       <h3>Polite</h3>
       <p id="some-text">Hello world.</p>
-      <button id="js-announce-el-polite">Announce</button>
+      <button id="js-announce-el-polite">Announce element politely</button>
 
       <h3>Assertive</h3>
       <p id="more-text">Goodbye for now.</p>
-      <button id="js-announce-el-assertive">Announce</button>
+      <button id="js-announce-el-assertive">Announce element assertively</button>
 
       <live-region>
         <template shadowrootmode="open">

--- a/src/live-region-element.ts
+++ b/src/live-region-element.ts
@@ -83,5 +83,16 @@ function getTemplate() {
   return template
 }
 
+declare global {
+  interface Window {
+    LiveRegionElement: typeof LiveRegionElement
+  }
+}
+
+if (!window.customElements.get('live-region')) {
+  window.LiveRegionElement = LiveRegionElement
+  window.customElements.define('live-region', LiveRegionElement)
+}
+
 export {LiveRegionElement, templateContent}
 export type {AnnounceOptions}


### PR DESCRIPTION
This PR adds an example demo page to showcase how this element can be used and to give consumers an example to interact with.

I've found the example pages that have been set up for our other custom elements helpful [example: auto-check-element](https://github.com/github/auto-check-element), so wanted to add one for this too!

#### Changelog

**New**

<!-- List of things added in this PR -->

**Changed**

<!-- List of things changed in this PR -->

**Removed**

<!-- List of things removed in this PR -->

#### Testing & Reviewing

<!-- Add descriptions, steps or a checklist for how reviewers can verify this PR works or not -->
