### PR TITLE
feat(live-region-element): add tag name to HTMLElementTagNameMap

### DIFF
--- a/packages/live-region-element/src/define.ts
+++ b/packages/live-region-element/src/define.ts
@@ -1,5 +1,11 @@
 import {LiveRegionElement} from './live-region-element'
 
+declare global {
+  interface HTMLElementTagNameMap {
+    'live-region': LiveRegionElement
+  }
+}
+
 if (!customElements.get('live-region')) {
   customElements.define('live-region', LiveRegionElement)
 }


### PR DESCRIPTION
Add `live-region` to the `HTMLElementTagName` map so that tools like `querySelector` work as-expected by giving you access to `LiveRegionElement` instead of a default `HTMLElement`

Thanks @khiga8 for pointing out that this was not working over in: https://github.com/primer/live-region-element/pull/4#pullrequestreview-1878035077 ✨ 

<!-- Short description of the PR. What does it do? -->

#### Changelog

**New**

<!-- List of things added in this PR -->

**Changed**

<!-- List of things changed in this PR -->

- Add `live-region` to `HTMLElementTagName` global

**Removed**

<!-- List of things removed in this PR -->

#### Testing & Reviewing

<!-- Add descriptions, steps or a checklist for how reviewers can verify this PR works or not -->

- Import the define entrypoint in a test file (or just write this in the define file itself)
- Write `document.querySelector('live-region')`
- Verify that the type points to `LiveRegionElement | null` and not `HTMLElement`
