### PR TITLE
feat: add support for priority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9850,7 +9850,7 @@
     },
     "packages/live-region-element": {
       "name": "@primer/live-region-element",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
@@ -9869,7 +9869,7 @@
     },
     "website": {
       "dependencies": {
-        "@primer/live-region-element": "^0.4.0",
+        "@primer/live-region-element": "^0.5.0",
         "a11y-dialog": "^8.0.4",
         "next": "^14.1.4",
         "react": "^18.2.0",


### PR DESCRIPTION
This is an exploration into adding in a concept of _priority_ to messages. Specifically, a message can have priority `immediate` or `background`. These should correspond to the idea of messages that are critical and ones that are information. 

This framing exposes a couple of questions:

- The priority levels seem to correspond to politeness, should we order the queue based on these politeness settings instead?
- How do we compare messages with different priorities but where one of higher priority is scheduled after one of lower priority?
