### PR TITLE
fix(live-region-element): update default throttle delay

### DIFF
--- a/.changeset/dull-cats-tap.md
+++ b/.changeset/dull-cats-tap.md
@@ -1,0 +1,5 @@
+---
+"@primer/live-region-element": patch
+---
+
+Update default throttle delay for announcements from 500ms to 150ms.

--- a/packages/live-region-element/src/live-region-element.ts
+++ b/packages/live-region-element/src/live-region-element.ts
@@ -36,7 +36,7 @@ type Cancel = () => void
 /**
  * The default delay between messages being announced by the live region
  */
-const DEFAULT_THROTTLE_DELAY_MS = 500
+const DEFAULT_THROTTLE_DELAY_MS = 150
 
 class LiveRegionElement extends HTMLElement {
   /**


### PR DESCRIPTION
This updates our default throttle delay to match with our current recommendations.

<!-- Short description of the PR. What does it do? -->

#### Changelog

**New**

<!-- List of things added in this PR -->

**Changed**

<!-- List of things changed in this PR -->

- Change default delay from `500` to `150`

**Removed**

<!-- List of things removed in this PR -->

#### Testing & Reviewing

<!-- Add descriptions, steps or a checklist for how reviewers can verify this PR works or not -->
