### PR TITLE
fix: inline ESM deps in CommonJS bundles

### DIFF
--- a/.changeset/large-cobras-jump.md
+++ b/.changeset/large-cobras-jump.md
@@ -1,0 +1,5 @@
+---
+"@primer/live-region-element": patch
+---
+
+Update the CommonJS bundles emitted to inline ESM-only dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,6 +1949,31 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "15.2.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.3.tgz",
+      "integrity": "sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.2.1",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-replace": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
@@ -2255,6 +2280,12 @@
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -3029,6 +3060,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -3585,6 +3628,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -5486,6 +5538,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5590,6 +5657,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -9456,6 +9529,7 @@
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.9.4",
         "@rollup/plugin-inject": "^5.0.5",
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.5",
         "jsdom": "^24.0.0",
         "publint": "^0.2.7",

--- a/packages/live-region-element/package.json
+++ b/packages/live-region-element/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.9.4",
     "@rollup/plugin-inject": "^5.0.5",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
     "jsdom": "^24.0.0",
     "publint": "^0.2.7",

--- a/packages/live-region-element/rollup.config.js
+++ b/packages/live-region-element/rollup.config.js
@@ -2,6 +2,10 @@ import inject from '@rollup/plugin-inject'
 import replace from '@rollup/plugin-replace'
 import esbuild from 'rollup-plugin-esbuild'
 import typescript from 'rollup-plugin-typescript2'
+import {nodeResolve} from '@rollup/plugin-node-resolve'
+
+const ESM_ONLY = new Set(['@lit-labs/ssr-dom-shim'])
+const external = ['@lit-labs/ssr-dom-shim']
 
 /**
  * @type {import('rollup').RollupOptions}
@@ -9,8 +13,8 @@ import typescript from 'rollup-plugin-typescript2'
 const config = [
   {
     input: ['./src/index.ts'],
-    external: ['@lit-labs/ssr-dom-shim'],
-    plugins: [typescript({tsconfig: 'tsconfig.build.json'}), esbuild()],
+    external,
+    plugins: [nodeResolve(), typescript({tsconfig: 'tsconfig.build.json'}), esbuild()],
     output: {
       dir: './dist/esm',
       format: 'esm',
@@ -18,8 +22,10 @@ const config = [
   },
   {
     input: ['./src/index.ts'],
-    external: ['@lit-labs/ssr-dom-shim'],
-    plugins: [typescript({tsconfig: 'tsconfig.build.json'}), esbuild()],
+    external: external.filter(dependency => {
+      return ESM_ONLY.has(dependency) === false
+    }),
+    plugins: [nodeResolve(), typescript({tsconfig: 'tsconfig.build.json'}), esbuild()],
     output: {
       dir: './dist/cjs',
       format: 'commonjs',
@@ -28,8 +34,9 @@ const config = [
   },
   {
     input: ['./src/index.ts'],
-    external: ['@lit-labs/ssr-dom-shim'],
+    external,
     plugins: [
+      nodeResolve(),
       esbuild(),
       // Reference:
       // https://github.com/lit/lit/blob/5c8b142552542ffa775b74074b8bd16f427a00fa/rollup-common.js#L260-L276
@@ -51,8 +58,11 @@ const config = [
   },
   {
     input: ['./src/index.ts'],
-    external: ['@lit-labs/ssr-dom-shim'],
+    external: external.filter(dependency => {
+      return ESM_ONLY.has(dependency) === false
+    }),
     plugins: [
+      nodeResolve(),
       esbuild(),
       // Reference:
       // https://github.com/lit/lit/blob/5c8b142552542ffa775b74074b8bd16f427a00fa/rollup-common.js#L260-L276


### PR DESCRIPTION
There is an issue when using `@primer/react` in Next.js projects due to the following error:

```
[unhandledRejection Error [ERR_REQUIRE_ESM]: require() of ES Module /app/node_modules/@lit-labs/ssr-dom-shim/index.js from /app/node_modules/@primer/live-region-element/dist/cjs/node/index.cjs not supported.
Instead change the require of index.js in /app/node_modules/@primer/live-region-element/dist/cjs/node/index.cjs to a dynamic import() which is available in all CommonJS modules.
```

This error occurs due to the usage of an ESM-only dependency in a CommonJS entrypoint. This PR inlines these dependencies as a result in order to avoid this problem.

<!-- Short description of the PR. What does it do? -->

#### Changelog

**New**

<!-- List of things added in this PR -->

**Changed**

<!-- List of things changed in this PR -->

- Inline ESM-only dependencies in CommonJS entrypoints for the package

**Removed**

<!-- List of things removed in this PR -->

#### Testing & Reviewing

<!-- Add descriptions, steps or a checklist for how reviewers can verify this PR works or not -->

- Run build locally for the package, verify that the `dist/cjs/node/index.cjs` file has inlined the lit-labs/ssr-dom-shim package
