### PR TITLE
test(live-region): add test for queueing announcements with throttle

### DIFF
--- a/packages/live-region-element/src/__tests__/live-region-element.test.ts
+++ b/packages/live-region-element/src/__tests__/live-region-element.test.ts
@@ -81,6 +81,22 @@ describe('live-region-element', () => {
     expect(liveRegion.getMessage('polite')).toBe('')
   })
 
+  test('queue announcements with announce()', async () => {
+    const delayMs = 150
+    liveRegion.delay = delayMs
+    liveRegion.announce('test1')
+    liveRegion.announce('test2')
+    liveRegion.announce('test3')
+
+    expect(liveRegion.getMessage('polite')).toBe('test1')
+
+    vi.advanceTimersByTime(delayMs)
+    expect(liveRegion.getMessage('polite')).toBe('test2')
+
+    vi.advanceTimersByTime(delayMs)
+    expect(liveRegion.getMessage('polite')).toBe('test3')
+  })
+
   test('announceFromElement()', () => {
     const element = document.createElement('div')
     element.textContent = 'test'


### PR DESCRIPTION
Add test for queueing announcements

<!-- Short description of the PR. What does it do? -->

#### Changelog

**New**

<!-- List of things added in this PR -->

**Changed**

<!-- List of things changed in this PR -->

- Update tests for live-region to include coverage for queueing announcements

**Removed**

<!-- List of things removed in this PR -->

#### Testing & Reviewing

<!-- Add descriptions, steps or a checklist for how reviewers can verify this PR works or not -->
