### PR TITLE
Fix race condition caused by calling `clear` immediately after `announce`

### DIFF
--- a/.changeset/silent-beds-suffer.md
+++ b/.changeset/silent-beds-suffer.md
@@ -1,0 +1,5 @@
+---
+"@primer/live-region-element": patch
+---
+
+Fix race condition caused by calling `clear` immediately after `announce`

--- a/packages/live-region-element/src/__tests__/live-region-element.test.ts
+++ b/packages/live-region-element/src/__tests__/live-region-element.test.ts
@@ -195,4 +195,18 @@ describe('live-region-element', () => {
       ).toBe(Ordering.Less)
     })
   })
+
+  test('announce() after clear()', async () => {
+    const delayMs = 500
+
+    liveRegion.announce('test1', {delayMs})
+    vi.advanceTimersByTime(delayMs)
+    expect(liveRegion.getMessage('polite')).toBe('test1')
+
+    liveRegion.clear()
+
+    liveRegion.announce('test2', {delayMs})
+    vi.advanceTimersByTime(delayMs)
+    expect(liveRegion.getMessage('polite')).toBe('test2')
+  })
 })

--- a/packages/live-region-element/src/__tests__/live-region-element.test.ts
+++ b/packages/live-region-element/src/__tests__/live-region-element.test.ts
@@ -197,16 +197,11 @@ describe('live-region-element', () => {
   })
 
   test('announce() after clear()', async () => {
-    const delayMs = 500
-
-    liveRegion.announce('test1', {delayMs})
-    vi.advanceTimersByTime(delayMs)
+    liveRegion.announce('test1')
     expect(liveRegion.getMessage('polite')).toBe('test1')
 
     liveRegion.clear()
-
-    liveRegion.announce('test2', {delayMs})
-    vi.advanceTimersByTime(delayMs)
+    liveRegion.announce('test2')
     expect(liveRegion.getMessage('polite')).toBe('test2')
   })
 })

--- a/packages/live-region-element/src/live-region-element.ts
+++ b/packages/live-region-element/src/live-region-element.ts
@@ -229,6 +229,7 @@ class LiveRegionElement extends HTMLElement {
       clearTimeout(this.#timeoutId)
       this.#timeoutId = null
     }
+    this.#pending = false
     this.#queue.clear()
   }
 }


### PR DESCRIPTION
`updateContainerWithMessage` sets `this.#pending = true` and cleans up once it's done. However, there can be a [timeout between finishing work and cleaning up](https://github.com/primer/live-region-element/blob/b238f8ea813d25be1c158f9d7398677c75118359/packages/live-region-element/src/live-region-element.ts#L208-L210)

If `liveRegion.clear()` is called immediately after `liveRegion.announce()`, i.e. before the above clean up step, it resets `this.#timeout` but not `this.#pending` leaving all future announcements in a pending state.

Caught it in [jest tests for SelectPanel](https://github.com/primer/react/pull/4968)

- [x] Add failing test
- [x] Add fix